### PR TITLE
Make unauthorized message general to make sense for any actor

### DIFF
--- a/lib/clean_architecture/strategies/actor_gets_authorized_then_does_work.rb
+++ b/lib/clean_architecture/strategies/actor_gets_authorized_then_does_work.rb
@@ -21,7 +21,7 @@ module CleanArchitecture
           if @authorization_check.authorized?
             @sub_strategy.result
           else
-            Dry::Monads::Failure('Unauthorized: Invalid API key')
+            Dry::Monads::Failure('Unauthorized')
           end
         end
       end

--- a/spec/clean_architecture/strategies/actor_gets_authorized_then_does_work_spec.rb
+++ b/spec/clean_architecture/strategies/actor_gets_authorized_then_does_work_spec.rb
@@ -32,7 +32,7 @@ module CleanArchitecture
 
           specify do
             expect(result).to be_a Dry::Monads::Failure
-            expect(result.failure).to eq 'Unauthorized: Invalid API key'
+            expect(result.failure).to eq 'Unauthorized'
           end
         end
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160049913

The current message being showed to someone that does not have the right permissions in maxwell for a feature is not helpful. It points to a wrong direction.

It happened in Maxwell suspicious orders to JayR.

![image from ios](https://user-images.githubusercontent.com/5819854/44636679-77aef500-a9f0-11e8-8afc-f81b8c0c7b93.png)
