### PR TITLE
Add has_many & belongs_to helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+
+  * `AbstractActiveRecordEntityBuilder` now has a DSL for streamlining the use of builders for `has_many` and `belongs_to` relations.
+
 2.2.0
 
   * Made `AbstractActiveRecordEntityBuilder` work with dry-struct >= 0.0.6.


### PR DESCRIPTION
This PR adds helpers to help DRY up builders when you want an array on your entity of a `has_many` or an instance for a `belongs_to`. Before this you would've had to override `#attributes_for_entity` and write a lot of boilerplate for every relation.

The new syntax looks as follows:
```ruby
class Person < ApplicationRecord
  has_many :interests, autosave: true, dependent: :destroy
  belongs_to :father
end

class Entities::Person < Dry::Struct
  attribute :forename, Types::Strict::String
  attribute :surname, Types::Strict::String
  attribute :father, Types.Instance(Person)
  attribute :interests, Types.Array(Types.Instance(Interest))
end

class PersonBuilder < CleanArchitecture::Builders::AbstractActiveRecordEntityBuilder
  acts_as_builder_for_entity Entities::Person

  has_many :interests, use: InterestBuilder
  belongs_to :father, use: PersonBuilder
end
```