### PR TITLE
Make AbstractUseCase work with dry-validation 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2.6.0
+
+  * Bring `UseCases::AbstractUseCase` into line with dry-validation 1.0 & co.
+    * Use cases now have a 'contract', params act as per normal
+    * Predicates have been replaced with macros, they can still be shared
+    * Context variables passed into the use case parameters are accessible within the use case as `context(:my_context)`
+    * There is no need to redefine `initialize` in use cases, you can access context with `#context` and params via `#result_of_validating_params`
+
 2.5.0
 
   * Remove restrictions on dry-rb gem

--- a/clean-architecture.gemspec
+++ b/clean-architecture.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'dry-struct'
   spec.add_dependency 'dry-types'
-  spec.add_dependency 'dry-validation'
+  spec.add_dependency 'dry-validation', '1.0.0.rc3'
   spec.add_dependency 'duckface-interfaces', '~> 0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.13'

--- a/lib/clean_architecture/entities/failure_details.rb
+++ b/lib/clean_architecture/entities/failure_details.rb
@@ -15,7 +15,7 @@ module CleanArchitecture
 
       attribute :type, FailureTypes
       attribute :message, Types::Strict::String
-      attribute :other_properties, Types::Strict::Hash.default({})
+      attribute :other_properties, Types::Strict::Hash.default({}.freeze)
 
       def self.from_array(array)
         new(message: array.map(&:to_s).join(', '), other_properties: {}, type: 'error')

--- a/lib/clean_architecture/use_cases/abstract_use_case.rb
+++ b/lib/clean_architecture/use_cases/abstract_use_case.rb
@@ -4,29 +4,35 @@ require 'dry/monads/result'
 require 'dry/validation'
 require 'dry/matcher/result_matcher'
 require 'clean_architecture/use_cases/errors'
+require 'clean_architecture/use_cases/parameters'
+require 'clean_architecture/use_cases/contract'
 require 'clean_architecture/entities/failure_details'
-
-Dry::Validation.load_extensions(:monads)
 
 module CleanArchitecture
   module UseCases
     class AbstractUseCase
       extend Forwardable
 
-      @params = nil
+      @contract = nil
 
-      def self.params(base_schema = nil)
-        @params ||= begin
-          if base_schema
-            Dry::Validation.Params(base_schema, &Proc.new)
-          else
-            Dry::Validation.Params(&Proc.new)
-          end
+      def self.contract(base_contract = Contract)
+        @contract ||= begin
+          Class.new(base_contract, &Proc.new)
         end
       end
 
-      def initialize
-        raise NotImplementedError
+      def self.parameters(params)
+        raise 'You must define a contract first' if @contract.nil?
+
+        context = params.fetch(:context, {})
+        Parameters.new(
+          context,
+          contract.new(context).call(params)
+        )
+      end
+
+      def initialize(params)
+        @params = params
       end
 
       def result
@@ -43,22 +49,12 @@ module CleanArchitecture
         Dry::Monads::Failure(new_errors)
       end
 
-      INVALID_PARAMS_FAILURE_TYPE = 'expectation_failed'
+      def result_of_validating_params
+        @params.to_monad
+      end
 
-      def result_of_validating_params(parameters)
-        Dry::Matcher::ResultMatcher.call(parameters.to_monad) do |matcher|
-          matcher.success { |valid_params| Dry::Monads::Success(valid_params) }
-
-          matcher.failure do |validation_errors|
-            new_errors = Errors.new(nil, INVALID_PARAMS_FAILURE_TYPE)
-            validation_errors.keys.each do |invalid_attribute_key|
-              validation_errors[invalid_attribute_key].each do |message|
-                new_errors.add(invalid_attribute_key, message)
-              end
-            end
-            Dry::Monads::Failure(new_errors)
-          end
-        end
+      def context(key)
+        @params.context(key)
       end
     end
   end

--- a/lib/clean_architecture/use_cases/contract.rb
+++ b/lib/clean_architecture/use_cases/contract.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module CleanArchitecture
+  module UseCases
+    class Contract < Dry::Validation::Contract
+    end
+  end
+end

--- a/lib/clean_architecture/use_cases/form.rb
+++ b/lib/clean_architecture/use_cases/form.rb
@@ -30,7 +30,7 @@ module CleanArchitecture
       # the parameter object or an exception
       def to_parameter_object
         @to_parameter_object ||= begin
-          use_case_class.params.with(context).call(parameter_object_hash)
+          use_case_class.parameters(parameter_object_hash.merge(context: context))
         end
       end
 
@@ -49,11 +49,11 @@ module CleanArchitecture
       end
 
       def self.acts_as_form_for(use_case_class)
-        attribute_names = use_case_class.params.rules.keys
+        attribute_names = use_case_class.contract.__schema__.rules.keys
 
         attribute_names.each do |attribute_name|
           define_method attribute_name do
-            to_parameter_object.to_h[attribute_name]
+            to_parameter_object[attribute_name]
           end
         end
 

--- a/lib/clean_architecture/use_cases/parameters.rb
+++ b/lib/clean_architecture/use_cases/parameters.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'dry/monads/result'
+require 'clean_architecture/use_cases/errors'
+
+module CleanArchitecture
+  module UseCases
+    class Parameters
+      include Dry::Monads::Result::Mixin
+      extend Forwardable
+
+      def initialize(context, dry_validation_result)
+        @context = context
+        @dry_validation_result = dry_validation_result
+      end
+
+      def context(key)
+        @context.fetch(key)
+      end
+
+      def_delegators :@dry_validation_result,
+                     :[]
+
+      def to_monad
+        @dry_validation_result.success? ? Success(@dry_validation_result.to_h) : Failure(errors)
+      end
+
+      INVALID_PARAMS_FAILURE_TYPE = 'expectation_failed'
+
+      def errors
+        new_errors = Errors.new(nil, INVALID_PARAMS_FAILURE_TYPE)
+        @dry_validation_result.errors.to_h.each_pair do |invalid_attribute_key, error_messages|
+          error_messages.each do |error_message|
+            new_errors.add(invalid_attribute_key, error_message)
+          end
+        end
+        new_errors
+      end
+    end
+  end
+end

--- a/lib/clean_architecture/version.rb
+++ b/lib/clean_architecture/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CleanArchitecture
-  VERSION = '2.5.1'
+  VERSION = '2.6.0'
 end

--- a/spec/lib/clean_architecture/use_cases/parameters_spec.rb
+++ b/spec/lib/clean_architecture/use_cases/parameters_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'dry-validation'
+require 'clean_architecture/use_cases/parameters'
+
+module CleanArchitecture
+  module UseCases
+    describe Parameters do
+      let(:parameters) { described_class.new(context, dry_validation_result) }
+
+      let(:context) do
+        { username: 'samuelgiles93' }
+      end
+      let(:dry_validation_result) { instance_double(Dry::Validation::Result) }
+
+      describe '#context' do
+        subject { parameters.context(:username) }
+
+        it { is_expected.to eq 'samuelgiles93' }
+      end
+
+      describe '[]' do
+        subject { parameters[:password] }
+
+        before do
+          expect(dry_validation_result).to receive(:[]).with(:password).and_return('top_secret')
+        end
+
+        it { is_expected.to eq 'top_secret' }
+      end
+
+      describe '#to_monad' do
+        subject(:result) { parameters.to_monad }
+
+        before do
+          expect(dry_validation_result)
+            .to receive(:success?)
+            .and_return(validation_successful)
+        end
+
+        context 'when validation was successful' do
+          let(:validation_successful) { true }
+
+          before do
+            expect(dry_validation_result).to receive(:to_h).and_return(password: 'top_secret')
+          end
+
+          specify do
+            expect(result).to be_an_instance_of(Dry::Monads::Success)
+            expect(result.value!).to eq(password: 'top_secret')
+          end
+        end
+
+        context "when validation wasn't successful" do
+          let(:validation_successful) { false }
+          let(:dry_validation_errors) { instance_double(Dry::Validation::MessageSet) }
+
+          before do
+            expect(dry_validation_result).to receive(:errors).and_return(dry_validation_errors)
+            expect(dry_validation_errors).to receive(:to_h).and_return(password: ['is super lame'])
+          end
+
+          specify do
+            expect(result).to be_an_instance_of(Dry::Monads::Failure)
+            expect(result.failure).to be_an_instance_of(Errors)
+            expect(result.failure.full_messages).to eq([
+              'Password is super lame'
+            ])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR gets the `AbstractUseCase` class working under `dry-validation`'s 1.0 overhaul. Use cases now have a `contract` where the `params` are specified. There is no longer a need to define an initializer for use cases as context variables are now available within the use case.

```ruby
     class ExampleSharedContract < Contract
        register_macro(:check_url_is_not_banned) do
          key.failure('is on the banned list') if values[key_name] == 'samuelgil.es'
        end
      end

      class ExampleUseCase < AbstractUseCase
        contract(ExampleSharedContract) do
          option :some_api

          params do
            required(:url_to_hit).filled(:str?)
          end
          
          rule(:url_to_hit).validate(:check_url_is_not_banned)
        end

        include Dry::Monads::Do.for(:result)

        def result
          valid_params = yield result_of_validating_params

          context(:some_api).new(valid_params[:url_to_hit])

          Dry::Monads::Success("We hit em!")
        end
      end
```

Using the parameters & use case is very similar:
```ruby
parameters = ExampleUseCase.parameters(
  context: { some_api: Net::HTTP },
  url_to_hit: 'http://google.com'
)
ExampleUseCase.new(parameters).result
```