### PR TITLE
Require forwardable before attempting to use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+5.0.2
+
+  * Require the forwardable module where it is used
+
+5.0.1
+
+  * Remove the version requirement on duckface-interfaces
+
 5.0.0
 
   * Rename persistence -> gateway to be consistent with the pattern used through our systems

--- a/lib/clean_architecture/checks/authorization.rb
+++ b/lib/clean_architecture/checks/authorization.rb
@@ -3,6 +3,7 @@
 
 require 'dry/monads/all'
 require 'clean_architecture/entities/failure_details'
+require 'forwardable'
 
 module CleanArchitecture
   module Checks

--- a/lib/clean_architecture/use_cases/abstract_use_case.rb
+++ b/lib/clean_architecture/use_cases/abstract_use_case.rb
@@ -8,6 +8,7 @@ require 'clean_architecture/use_cases/errors'
 require 'clean_architecture/use_cases/parameters'
 require 'clean_architecture/use_cases/contract'
 require 'clean_architecture/entities/failure_details'
+require 'forwardable'
 
 module CleanArchitecture
   module UseCases

--- a/lib/clean_architecture/use_cases/errors.rb
+++ b/lib/clean_architecture/use_cases/errors.rb
@@ -3,6 +3,7 @@
 
 require 'active_model'
 require 'active_support/core_ext/string/inflections'
+require 'forwardable'
 
 module CleanArchitecture
   module UseCases

--- a/lib/clean_architecture/use_cases/parameters.rb
+++ b/lib/clean_architecture/use_cases/parameters.rb
@@ -3,6 +3,7 @@
 
 require 'dry/monads/result'
 require 'clean_architecture/use_cases/errors'
+require 'forwardable'
 
 module CleanArchitecture
   module UseCases

--- a/lib/clean_architecture/version.rb
+++ b/lib/clean_architecture/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module CleanArchitecture
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 end


### PR DESCRIPTION
When using `clean-architecture` in an app where `forwardable` has not been required, the app fails to boot with `uninitialized constant CleanArchitecture::Checks::Authorization::Forwardable`. It could fail in any of the modules where `Forwardable`  is used. This PR adds the `require` statements in all the modules where it is used to fix this.